### PR TITLE
Access Closure Compiler via HTTPS (Chromium issue #760416).

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -7,7 +7,7 @@ import urllib.parse
 import urllib.request
 
 BASE_DIR = os.path.dirname(sys.argv[0])
-CLOSURE_URL = 'http://closure-compiler.appspot.com/compile'
+CLOSURE_URL = 'https://closure-compiler.appspot.com/compile'
 TARGET_JS = os.path.join(BASE_DIR, 'sample', 'chrome-nfc.js')
 
 def print_errors(errors, js_files):


### PR DESCRIPTION
Currently, the Closure Compiler web service is accessed via HTTP. If the request is intercepted, the compiled Javascript may be replaced with something else.  This patch uses HTTPS instead, which on modern versions of Python also validates certificates.

Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=760416